### PR TITLE
Use repo.magento.com for phpcs ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Clone repository..
 git clone git@github.com:bennoislost/magento-module-skeleton.git .
 ```
 
+To install the `magento/magento-eqp` package you will have to authenticate against `repo.magento.com`
+
+```
+"http-basic": {
+    "repo.magento.com": {
+        "username":"<your public key>",
+        "password":"<your private key>"
+    }
+}
+```
+
+You can create magento authentication keys here: [http://devdocs.magento.com/guides/v2.0/install-gde/prereq/connect-auth.html](http://devdocs.magento.com/guides/v2.0/install-gde/prereq/connect-auth.html)
+
+You can define Composer authentication here: [https://getcomposer.org/doc/articles/http-basic-authentication.md](https://getcomposer.org/doc/articles/http-basic-authentication.md)
+
 ## Usage
 
 `composer install` command will download and extract magento core with useful development modules into `./magento`. From here you can use a tool like `n98-magerun.phar` to create your skeleton module structure.

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
             "url": "https://packages.firegento.com"
         },
         "magento-eqp": {
-            "type": "git",
-            "url": "https://github.com/magento/marketplace-eqp"
+            "type": "composer",
+            "url": "https://repo.magento.com"
         }
     },
     "extra": {
@@ -54,7 +54,7 @@
         "mage:redeploy": "@composer run-script post-install-cmd -vvv -- --redeploy",
         "mage:cache:flush": "rm -rf magento/var/cache/*",
         "tests": "bin/behat -v",
-        "sniff": "bin/phpcs --standard=vendor/magento/marketplace-eqp/MEQP1 magento/app/code/core/Mage/Cms/{Block,Model,Helper}"
+        "sniff": "bin/phpcs --standard=vendor/magento/marketplace-eqp/MEQP1 magento/app/code/core/Mage/GoogleAnalytics/{Block,Model,Helper}"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
Use repository for magento-eqp package
instead of development version

allows use of offical Magento
coding standard